### PR TITLE
Update to Java 17 baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ This sample project demonstrates a Spring Boot application running asynchronous 
 
 ## Prerequisites
 
-  - CICS TS V5.3 or later
+  - CICS TS V5.6 or later (required for Java 17 support)
   - A configured Liberty JVM server in CICS
-  - Java SE 1.8 or later on the workstation
+  - Java SE 17 or later on the workstation
   - An Eclipse development environment on the workstation (optional)
   - Either Gradle or Apache Maven on the workstation (optional if using Wrappers)
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@
 #
 
 # Java version for toolchain
-java_version = 8
+java_version = 17
 
 # Gradle build optimizations
 org.gradle.daemon=true

--- a/pom.xml
+++ b/pom.xml
@@ -16,12 +16,11 @@
   <name>cics-java-liberty-springboot-asynchronous</name>
   <description>Demo project for Spring Boot</description>      
   <properties>
-    <java.version>1.8</java.version>
-
+    <java.version>17</java.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.target>${java.version}</maven.compiler.target>
     <maven.compiler.source>${java.version}</maven.compiler.source>
-  </properties>   
+  </properties>
      
   <!-- CICS TS V5.5 BOM (as of May 2020) -->
   <dependencyManagement>
@@ -61,6 +60,14 @@
   <packaging>war</packaging>
   <build>
     <plugins>
+      <!-- Maven Compiler Plugin with release parameter -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <release>${java.version}</release>
+        </configuration>
+      </plugin>
       <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>


### PR DESCRIPTION
Java 17 is required as the foundation for Spring Boot 3.x upgrade.

Changes:
- Updated java.version to 17 in pom.xml
- Added Maven compiler plugin with release parameter
- Updated java_version to 17 in gradle.properties
- Updated README prerequisites to Java SE 17
- Updated CICS TS requirement to V5.6+ (minimum for Java 17)

This establishes the Java 17 baseline required for Spring Boot 3.x.