### PR TITLE
Modernize GitHub Actions workflows

### DIFF
--- a/.github/workflows/cleanup-old-runs.yml
+++ b/.github/workflows/cleanup-old-runs.yml
@@ -1,0 +1,24 @@
+name: Cleanup Old Workflow Runs
+
+on:
+  schedule:
+    - cron: '0 0 * * 0'  # Run weekly on Sunday at midnight UTC
+  workflow_dispatch:  # Allow manual triggering
+
+permissions:
+  actions: write
+  contents: read
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete old workflow runs
+        uses: Mattraks/delete-workflow-runs@v2
+        with:
+          token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          retain_days: 30
+          keep_minimum_runs: 3
+
+# Made with Bob

--- a/.github/workflows/java.yaml
+++ b/.github/workflows/java.yaml
@@ -1,85 +1,90 @@
 name: Build
 
+permissions:
+  contents: read
+
 on:
   push:
-    branches: ["main"]
+    branches: ["main", "spring-boot-3-modernization"]
   pull_request:
-    branches: ["main"]
+    branches: ["main", "spring-boot-3-modernization"]
   schedule:
     - cron: '0 0 * * *'
 
 jobs:
+  check-copyright:
+    runs-on: ubuntu-latest
+    name: Check Copyright
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - id: copyright-action
+        uses: cicsdev/.github/.github/actions/samples-copyright-checker@4134522d8109169bb8c460db841f94167ec2802f
+        with:
+          directory: './cics-java-liberty-springboot-asynchronous-app/'
+          file-extensions: '*.java'
+          base-copyright: 'Copyright IBM Corp. 2026'
+          token: ${{ secrets.GITHUB_TOKEN }}
+
   build-maven:
     name: Build Maven
 
     runs-on: ubuntu-latest
-    continue-on-error: ${{ matrix.experimental }}
     strategy:
       matrix:
-        jdk: [8, 11]
-        experimental: [false]
-        include:
-          - jdk: 17
-            experimental: true
+        jdk: [17, 21, 25]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up JDK ${{ matrix.jdk }}
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.jdk }}
           distribution: "semeru"
           cache: maven
       - name: Build with Maven
-        run: mvn --batch-mode --update-snapshots --file pom.xml -Djava.version=${{ matrix.jdk }} package
+        run: mvn --batch-mode --update-snapshots --file pom.xml package
       - run: mkdir staging && cp target/*.war staging
       - uses: actions/upload-artifact@v4
         with:
-          name: cics-java-liberty-sprintboot-asynchronous (Maven, Java ${{ matrix.jdk }})
+          name: cics-java-liberty-springboot-asynchronous-maven-java${{ matrix.jdk }}
           path: staging
 
   build-mvnw:
     name: Build Maven Wrapper
 
     runs-on: ubuntu-latest
-    continue-on-error: ${{ matrix.experimental }}
     strategy:
       matrix:
-        jdk: [8, 11]
-        experimental: [false]
-        include:
-          - jdk: 17
-            experimental: true
+        jdk: [17, 21, 25]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up JDK ${{ matrix.jdk }}
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.jdk }}
           distribution: "semeru"
           cache: maven
-      - name: Build with Maven
-        run: ./mvnw --batch-mode --update-snapshots --file pom.xml -Djava.version=${{ matrix.jdk }} package
+      - name: Build with Maven Wrapper
+        run: ./mvnw --batch-mode --update-snapshots package
 
   build-gradle:
     name: Build Gradle
     
     runs-on: ubuntu-latest
-    continue-on-error: ${{ matrix.experimental }}
     strategy:
       matrix:
-        jdk: [8, 11]
-        experimental: [false]
-        include:
-          - jdk: 17
-            experimental: true
+        jdk: [17, 21, 25]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up JDK ${{ matrix.jdk }}
       uses: actions/setup-java@v4
       with:
         java-version: ${{ matrix.jdk }}
         distribution: 'semeru'
     - name: Build with Gradle
-      uses: gradle/gradle-build-action@bd5760595778326ba7f1441bcf7e88b49de61a25 # v2.6.0
+      uses: gradle/actions/setup-gradle@v4
       with:
-        arguments: bootWar -Pjava_version=${{ matrix.jdk }}
+        gradle-version: 8.14.4
+    - name: Execute Gradle build
+      run: ./gradlew bootWar


### PR DESCRIPTION
Updated CI/CD workflows to modern standards with Java 17+ support.

Changes to java.yaml:
- Added permissions block (contents: read)
- Updated Java version matrix to 17, 21, 25 (all stable, none experimental)
- Updated action versions to v4 (checkout, setup-java, upload-artifact)
- Added copyright checking job using cicsdev reusable action
- Updated Gradle action to gradle/actions/setup-gradle@v4
- Added explicit Gradle version 8.14.4 for CICS Bundle Plugin compatibility
- Added work branch (spring-boot-3-modernization) to trigger branches
- Removed -Djava.version parameter (now uses centralized property)
- Fixed artifact naming for uniqueness
- Copyright directory points to -app module for multi-module structure

Added cleanup-old-runs.yml:
- Automatic cleanup of old workflow runs
- 30-day retention with minimum 3 runs
- Weekly schedule (Sunday midnight UTC)
- Manual trigger support

This modernizes CI/CD infrastructure before Spring Boot 3 upgrade.