### PR TITLE
Update CICS BOM to 6.1-20250812133513-PH63856

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,13 +20,13 @@ This sample project demonstrates a Spring Boot application running asynchronous 
 
 ### Check dependencies
  
-Before building this sample, you should verify that the correct CICS TS bill of materials (BOM) is specified for your target release of CICS. The BOM specifies a consistent set of artifacts, and adds information about their scope. In the example below the version specified is compatible with CICS TS V5.5 with JCICS APAR PH25409, or newer. That is, the Java byte codes built by compiling against this version of JCICS will be compatible with later CICS TS versions and subsequent JCICS APARs.
+Before building this sample, you should verify that the correct CICS TS bill of materials (BOM) is specified for your target release of CICS. The BOM specifies a consistent set of artifacts, and adds information about their scope. In the example below the version specified is compatible with CICS TS V6.1 with JCICS APAR PH63856, or newer. That is, the Java byte codes built by compiling against this version of JCICS will be compatible with later CICS TS versions and subsequent JCICS APARs.
 
 You can browse the published versions of the CICS BOM at [Maven Central.](https://mvnrepository.com/artifact/com.ibm.cics/com.ibm.cics.ts.bom)
  
 Gradle (build.gradle):
 
-`compileOnly enforcedPlatform("com.ibm.cics:com.ibm.cics.ts.bom:5.5-20200519131930-PH25409")`
+`compileOnly(enforcedPlatform("com.ibm.cics:com.ibm.cics.ts.bom:6.1-20250812133513-PH63856"))`
 
 Maven (POM.xml):
 
@@ -36,7 +36,7 @@ Maven (POM.xml):
     <dependency>
       <groupId>com.ibm.cics</groupId>
       <artifactId>com.ibm.cics.ts.bom</artifactId>
-      <version>5.5-20200519131930-PH25409</version>
+      <version>6.1-20250812133513-PH63856</version>
       <type>pom</type>
       <scope>import</scope>
     </dependency>

--- a/build.gradle
+++ b/build.gradle
@@ -48,9 +48,10 @@ dependencies
     // Don't include TomCat in the runtime build, but do put it in WEB-INF so it can be run standalone a well as embedded
     providedRuntime("org.springframework.boot:spring-boot-starter-tomcat")
   
-    // CICS TS V5.5 Maven BOM (as of 19th May 2020)
-    compileOnly enforcedPlatform("com.ibm.cics:com.ibm.cics.ts.bom:5.5-20200519131930-PH25409")
-      
-    // Don't include JCICS in the final build (no need for version because we have BOM)
-    compileOnly("com.ibm.cics:com.ibm.cics.server")                
+    // Use correct BOM version for CICS TS (6.1 is the minimum supported release for this sample)
+    // If you are running on a higher CICS TS version, you may replace this with a newer BOM)
+    compileOnly(enforcedPlatform("com.ibm.cics:com.ibm.cics.ts.bom:6.1-20250812133513-PH63856"))
+    
+    // JCICS API (version inherited from BOM)
+    compileOnly("com.ibm.cics:com.ibm.cics.server")
 }

--- a/pom.xml
+++ b/pom.xml
@@ -22,13 +22,14 @@
     <maven.compiler.source>${java.version}</maven.compiler.source>
   </properties>
      
-  <!-- CICS TS V5.5 BOM (as of May 2020) -->
+  <!--Use correct BOM version for CICS TS (6.1 is the minimum supported release for this sample) -->
+  <!-- If you are running on a higher CICS TS version, you may replace this with a newer BOM) -->
   <dependencyManagement>
     <dependencies>
       <dependency>
         <groupId>com.ibm.cics</groupId>
         <artifactId>com.ibm.cics.ts.bom</artifactId>
-        <version>5.5-20200519131930-PH25409</version>
+        <version>6.1-20250812133513-PH63856</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
- Update BOM version in pom.xml from 5.5 to 6.1
- Update BOM version in build.gradle from 5.5 to 6.1
- Update README documentation with new BOM version
- Align comments with JCICS repository standards
- BOM now compatible with CICS TS V6.1 with APAR PH63856