### PR TITLE
Upgrade to Spring Boot 3.5.14

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins
 {
-	id 'org.springframework.boot' version '2.7.0'
-	id 'io.spring.dependency-management' version '1.0.11.RELEASE'
+	id 'org.springframework.boot' version '3.5.14'
+	id 'io.spring.dependency-management' version '1.1.7'
 	id 'java'
 	id 'eclipse'
 	id 'idea'

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,8 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.7.0</version>
+    <version>3.5.14</version>
+    <relativePath/>
   </parent>
   
   <!-- Application properties -->


### PR DESCRIPTION
- Update Spring Boot version from 2.7.0 to 3.5.14 in pom.xml
- Update Spring Boot version from 2.7.0 to 3.5.14 in build.gradle
- Update dependency-management plugin from 1.0.11.RELEASE to 1.1.7
- Add relativePath to parent POM for consistency
- Spring Boot 3.x requires Java 17+ and Jakarta EE 10
- No code changes needed (no javax.* imports found)