### PR TITLE
Update Liberty server.xml for Spring Boot 3

### DIFF
--- a/etc/config/liberty/server.xml
+++ b/etc/config/liberty/server.xml
@@ -4,8 +4,8 @@
 	<!-- Enable features -->
 	<featureManager>
 		<feature>cicsts:core-1.0</feature>
-		<feature>servlet-3.1</feature>
-		<feature>concurrent-1.0</feature>
+		<feature>servlet-6.0</feature>
+		<feature>concurrent-3.0</feature>
 	</featureManager>
 
     <!-- Default HTTP End Point -->


### PR DESCRIPTION
- Update servlet feature from servlet-3.1 to servlet-6.0 (Jakarta EE 10)
- Update concurrent feature from concurrent-1.0 to concurrent-3.0
- Aligns with Spring Boot 3.x requirements and README documentation