### PR TITLE
Fix root Eclipse configuration for multi-module project

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="src" output="bin/main" path="src/main/java">
+	<classpathentry exported="true" kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17">
 		<attributes>
-			<attribute name="gradle_scope" value="main"/>
-			<attribute name="gradle_used_by_scope" value="main,test"/>
+			<attribute name="module" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8/"/>
 	<classpathentry kind="output" path="bin/default"/>
 </classpath>
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
-/.gradle/
-/target/
-/build/
-/bin/
+.gradle/
+target/
+build/
+bin/
+*.war
+*.jar
 


### PR DESCRIPTION
- Update .gitignore to use directory patterns instead of root-level patterns
  - Ensures build artifacts in sub-modules are properly ignored
  - Adds *.war and *.jar patterns for artifact exclusion
- Update root .classpath to reference JavaSE-17 (was JavaSE-1.8)
- Simplify root .classpath to minimal structure for parent POM
  - Remove source folder references (source is in child modules)
  - Aligns with multi-module Eclipse configuration standards

Fixes three critical issues identified in validation against Agents_CONSOLIDATED.md