### PR TITLE
fix: standardize workflow triggers to target main branch only

### DIFF
--- a/.github/workflows/java.yaml
+++ b/.github/workflows/java.yaml
@@ -7,7 +7,7 @@ on:
   push:
     branches: ["main"]
   pull_request:
-    branches: ["**"]
+    branches: ["main"]
   schedule:
     - cron: '0 0 * * *'
 


### PR DESCRIPTION
- Changed pull_request trigger from branches: ["**"] to ["main"]
- Aligns with standard pattern where all PRs target main branch
- Work branch was temporary exception, now standardizing across all repos