### PR TITLE
Update Eclipse project configuration and README

### DIFF
--- a/.project
+++ b/.project
@@ -1,10 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>com.ibm.cicsdev.springboot.asynchronous</name>
+	<name>cics-java-liberty-springboot-asynchronous</name>
 	<comment></comment>
 	<projects>
 	</projects>
 	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.buildship.core.gradleprojectbuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
 		<buildCommand>
 			<name>org.eclipse.jdt.core.javabuilder</name>
 			<arguments>
@@ -17,11 +22,6 @@
 		</buildCommand>
 		<buildCommand>
 			<name>org.eclipse.wst.validation.validationbuilder</name>
-			<arguments>
-			</arguments>
-		</buildCommand>
-		<buildCommand>
-			<name>org.eclipse.buildship.core.gradleprojectbuilder</name>
 			<arguments>
 			</arguments>
 		</buildCommand>

--- a/.settings/org.eclipse.wst.common.component
+++ b/.settings/org.eclipse.wst.common.component
@@ -1,8 +1,13 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project-modules id="moduleCoreId" project-version="1.5.0">
-	<wb-module deploy-name="com.ibm.cicsdev.springboot.asynchronous">
-		<property name="context-root" value="cics-java-liberty-springboot-asynchronous"/>
-		<wb-resource deploy-path="/WEB-INF/classes" source-path="src/main/java"/>
-		<wb-resource deploy-path="/" source-path="src/main/webapp"/>
-	</wb-module>
+<?xml version="1.0" encoding="UTF-8"?><project-modules id="moduleCoreId" project-version="1.5.0">
+    	
+    <wb-module deploy-name="cics-java-liberty-springboot-asynchronous">
+        		
+        <property name="context-root" value="cics-java-liberty-springboot-asynchronous"/>
+        		
+        <wb-resource deploy-path="/WEB-INF/classes" source-path="src/main/java"/>
+        		
+        <wb-resource deploy-path="/" source-path="src/main/webapp"/>
+        	
+    </wb-module>
+    
 </project-modules>

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Ensure you have the following features defined in your Liberty `server.xml`:
   
 A template `server.xml` is provided [here](./etc/config/liberty/server.xml).
     
-### Deploying with CICS bundles
+### Deploying with a CICS Bundle Project 
 1. Copy and paste the built WAR from your *target* or *build/libs* directory into a Eclipse CICS bundle project.
 2. Create a new WAR bundlepart that references the WAR file.
 3. Deploy the CICS bundle project from CICS Explorer using the **Export Bundle Project to z/OS UNIX File System** wizard.


### PR DESCRIPTION
- Update project name in .project to match repository name
- Reorder build commands in .project for consistency
- Update .settings/org.eclipse.wst.common.component configuration
- Clarify README wording: 'CICS bundles' -> 'CICS Bundle Project'