### PR TITLE
Add Eclipse encoding configuration for cicsbundle module

### DIFF
--- a/cics-java-liberty-springboot-asynchronous-cicsbundle/.settings/org.eclipse.core.resources.prefs
+++ b/cics-java-liberty-springboot-asynchronous-cicsbundle/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8


### PR DESCRIPTION
- Add org.eclipse.core.resources.prefs to cicsbundle module
- Sets UTF-8 encoding to resolve Eclipse warning