### PR TITLE
Validation fixes: build config, CI workflow, Eclipse settings, Maven wrapper, README

### DIFF
--- a/cics-java-liberty-springboot-asynchronous-app/.classpath
+++ b/cics-java-liberty-springboot-asynchronous-app/.classpath
@@ -2,6 +2,11 @@
 <classpath>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17/"/>
 	<classpathentry kind="con" path="org.eclipse.jst.j2ee.internal.web.container"/>
+	<classpathentry kind="con" path="com.ibm.cics.explorer.sdk.web.LIBERTY_LIBRARIES/L./V.61/JE.JEE_V10_R0">
+		<attributes>
+			<attribute name="owner.project.facets" value="jst.web"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.buildship.core.gradleclasspathcontainer">
 		<attributes>
 			<attribute name="org.eclipse.jst.component.dependency" value="/WEB-INF/lib"/>


### PR DESCRIPTION
Validation against standards.

Key changes:
- Spring Boot 3.5.14 to 3.5.16
- Maven wrapper 3.9.9 bin to 3.9.12 only-script
- foojay toolchain resolver and JDK auto-provisioning
- WAR naming fixed (archivesName replaced with archiveFileName)
- CI: removed schedule cron, added copyright checker permissions, fixed gradle jobs (bootWar to build), added -Djava.version to Maven jobs
- cleanup workflow: keep_minimum_runs 3 to 6
- Eclipse app .classpath: added CICS Liberty Libraries entry (V6.1, Jakarta EE 10)
- Eclipse app .settings/org.eclipse.jdt.core.prefs: completed to standard template
- cicsbundle pom.xml: restored project.groupId idiom
- README: corrected WAR output paths, application element names, context root URLs
- MAINTAINERS: updated review date to July 2026