### PR TITLE
Fix .gitignore gradle-wrapper.jar exception and remove deprecated mav…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,6 @@ bin/
 *.war
 *.jar
 
-
+# Avoid ignoring Gradle wrapper jar and properties (needed for wrapper to work)
+!gradle-wrapper.jar
+!gradle-wrapper.properties

--- a/pom.xml
+++ b/pom.xml
@@ -20,8 +20,6 @@
   <properties>
     <java.version>17</java.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.target>${java.version}</maven.compiler.target>
-    <maven.compiler.source>${java.version}</maven.compiler.source>
     <cics.jvmserver>DFHWLP</cics.jvmserver>
   </properties>
    


### PR DESCRIPTION
- .gitignore: add !gradle-wrapper.jar and !gradle-wrapper.properties exceptions to prevent blanket *.jar rule from silently dropping the wrapper jar from git tracking
- pom.xml: remove deprecated maven.compiler.source/target properties; release parameter is already correctly configured via maven-compiler-plugin <release> in the build section